### PR TITLE
Replace wget with requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ matplotlib
 numpy
 pandas
 tqdm
-wget
+requests

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
-     install_requires=['scipy','matplotlib','numpy','pandas','tqdm','peakdetect','wget'],
+     install_requires=['scipy','matplotlib','numpy','pandas','tqdm','peakdetect','requests'],
      python_requires='>=3',
      name='findpeaks',
      version=new_version,


### PR DESCRIPTION
The repository for the wget library (used for importing example data) is no longer available. Although it is still available on PyPI, it hasn't been updated in over 5 years and presumably won't be able to receive to security or bugfix updates in the future. This switches to the common requests library instead.

It also introduces a datadir parameter to the function which allows data to be downloaded to a different directory. This is useful if the library is installed system-wide as a regular user will not have permission to download files to the system directory.